### PR TITLE
Shuffling MCs when selecting a subsample

### DIFF
--- a/src/srcsim/scripts/sim_run.py
+++ b/src/srcsim/scripts/sim_run.py
@@ -1,6 +1,7 @@
 import yaml
 import datetime
 import argparse
+import random
 import pandas as pd
 import astropy.units as u
 
@@ -51,7 +52,12 @@ def main():
 
     for emission_type in mc:
         if cfg['mc'][emission_type]['max_samples'] is not None:
-            mc[emission_type].samples = mc[emission_type].samples[:cfg['mc'][emission_type]['max_samples']]
+            mc[emission_type].samples = tuple(
+                random.sample(
+                    mc[emission_type].samples,
+                    cfg['mc'][emission_type]['max_samples']
+                )
+            )
 
     print(mc)
 


### PR DESCRIPTION
**Issue:** `simrun` uses the MC list as when applying a  `max_samples` cut on the maximal number of entries. If MCs are ordered (e.g. with the pointing direction), this results in cutting a representative part of MC samples and may lead to the simulation crash (no MCs suitable for a given pointing).

**Solution:** shuffle MC samples prior to applying the `max_samples` cut.