### PR TITLE
Save source name in the generated event tables

### DIFF
--- a/src/srcsim/run.py
+++ b/src/srcsim/run.py
@@ -240,7 +240,7 @@ f"""{type(self).__name__} instance
                     )
 
                 evt = evt.drop('mc_src_name', errors='ignore')
-                evt.assign(
+                evt = evt.assign(
                     mc_src_name = np.repeat(source.name, len(evt))
                 )
 

--- a/src/srcsim/run.py
+++ b/src/srcsim/run.py
@@ -239,6 +239,11 @@ f"""{type(self).__name__} instance
                         reco_dec = np.zeros(0)
                     )
 
+                evt = evt.drop('mc_src_name', errors='ignore')
+                evt.assign(
+                    mc_src_name = np.repeat(source.name, len(evt))
+                )
+
                 events.append(evt)
 
         events = pd.concat(events)


### PR DESCRIPTION
Saving in the source name corresponding to each simulated event enables deeper study of the simulated data set,  e.g. true background evaluation and per-source contribution estimate to the measured signal.