### PR TITLE
FitsCube support of the energy column

### DIFF
--- a/src/srcsim/src.py
+++ b/src/srcsim/src.py
@@ -230,7 +230,7 @@ f"""{type(self).__name__} instance
             (energies.to('dex(MeV)').value,),
             z,
             bounds_error = False,
-            fill_value = 0,
+            fill_value = -1,
         )
 
         return interp

--- a/src/srcsim/src.py
+++ b/src/srcsim/src.py
@@ -236,7 +236,7 @@ f"""{type(self).__name__} instance
         return interp
 
     def energy_to_pixel(self, energy):
-        return self._energy_interpolator(energy.to('dex(MeV)'))
+        return self._energy_interpolator(energy.to('dex(MeV)').value)
 
     def cube_value(self, x, y, z):
         val = self._cube_interpolator(list(zip(x.flatten(), y.flatten(), z.flatten()))) * self.cube.unit


### PR DESCRIPTION
Adds `FitsCubeSource` support for the energy axis specification via FITS table in the "ENERGIES" extension. If such an extension is missing, falls back to retrieving the energy axis from the WCS defined in the primary extension header.