### PR TITLE
Support for analytical spectrum with 2D spatial model

### DIFF
--- a/src/srcsim/src.py
+++ b/src/srcsim/src.py
@@ -159,7 +159,7 @@ class FitsMapSource(Source):
         super().__init__(emission_type, pos=pos, dnde=dnde, name=name)
 
         self.file_name = file_name
-        self.map = map
+        self.sky_map = sky_map
         self.wcs = wcs
 
     def __repr__(self):

--- a/src/srcsim/src.py
+++ b/src/srcsim/src.py
@@ -188,12 +188,15 @@ f"""{type(self).__name__} instance
             if 'BSCALE' in hdus['primary'].header:
                 scale = hdus['primary'].header['BSCALE']
 
-            # if 'BUNIT' in hdus['primary'].header:
-            #     unit = u.Unit(hdus['primary'].header['BUNIT'])
-            # else:
-            #     raise ValueError("No 'BUNIT' keyword in the primary extension header")
+            if 'BUNIT' in hdus['primary'].header:
+                unit = u.Unit(hdus['primary'].header['BUNIT'])
+            else:
+                # raise ValueError("No 'BUNIT' keyword in the primary extension header")
+                pixel_area = wcs.celestial.proj_plane_pixel_area()
+                n_pixels = np.prod(wcs.celestial.array_shape)
+                unit = 1 / (pixel_area * n_pixels)
 
-            sky_map = (hdus['primary'].data.transpose() - zero) * scale #* unit
+            sky_map = (hdus['primary'].data.transpose() - zero) * scale * unit
 
         return sky_map, wcs
 

--- a/src/srcsim/src.py
+++ b/src/srcsim/src.py
@@ -196,6 +196,13 @@ f"""{type(self).__name__} instance
 
         return sky_map, wcs
 
+    def dndo(self, coord):
+        x, y = self.wcs.world_to_pixel(coord)
+        x, y = np.int16(
+            np.floor((x,y))
+        )
+        return self.sky_map[x, y]
+
 class FitsCubeSource(Source):
     def __init__(self, emission_type, file_name, name='fits_source'):
         cube, wcs = self.read_data(file_name)


### PR DESCRIPTION
Closes #9 

Adds new `FitsMapSource` source class that joins the analytical spectral model with the 2D FITS map of the surface brightness. The class may be set for a given source indicating the "fitsmap" spatial model type.

`FitsMapSource` assumes the sky map FITS defines the flux unit in the "BUNIT" keyword of the primary extension; if the keyword is missing it will deduce it assuming a unitary total flux from the total sky area covered by world coordinate system, defined in the header.

Usage example in the config file:
```yaml
sources:
    - name: "diffuse_source"
      emission_type: "gamma"
      spatial:
          type: 'fitsmap'
          file_name: 'sky_map.fits'
      spectral:
          type: 'pwlec'
          norm: '1.0e-25 1/(cm2 s eV)'
          e0: '1 TeV'
          index: -2
          ecut: '10 TeV'
```