### PR TITLE
Python 3.12 and LST Prod6 MCs multi-telescope support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,12 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "astropy==5.1",
+    "astropy>=5.1",
     "numpy>=1.21.0",
-    "pandas==1.4.1",
+    "pandas>=1.4.1",
     "scipy>=1.5.0",
-    "tables==3.7.0",
-    "PyYAML==5.3.1"
+    "tables>=3.7.0",
+    "PyYAML>=5.3.1"
 ]
 
 [project.urls]

--- a/src/srcsim/mc.py
+++ b/src/srcsim/mc.py
@@ -128,15 +128,17 @@ class MCSample(MCBase):
             self.config_table = self.read_config(file_name, obs_id)
             self.data_table = self.read_data(file_name, obs_id)
 
+        self.data_table = self._fix_format(self.data_table)
+        self.config_table = self._fix_format(self.config_table)
 
         # Getting the telescope pointing
-        pointing_data = self.data_table[['mc_az_tel', 'mc_alt_tel']].mean()
-        self.tel_pos = SkyCoord(pointing_data['mc_az_tel'], pointing_data['mc_alt_tel'], unit=self.units['angle'], frame='altaz')
+        pointing_data = self.data_table[['pointing_az', 'pointing_alt']].mean()
+        self.tel_pos = SkyCoord(pointing_data['pointing_az'], pointing_data['pointing_alt'], unit=self.units['angle'], frame='altaz')
         
         # Working out the simulation spectrum
         rmin, rmax = self.config_table[['min_scatter_range', 'max_scatter_range']].iloc[0] * self.units['distance']
         ground_area = np.pi * (rmax**2 - rmin**2)
-        nevents = self.config_table['num_showers'].iloc[0] * self.config_table['shower_reuse'].iloc[0]
+        nevents = self.config_table['n_showers'].iloc[0] * self.config_table['shower_reuse'].iloc[0]
         emin = self.config_table['energy_range_min'].iloc[0] * self.units['energy']
         emax = self.config_table['energy_range_max'].iloc[0] * self.units['energy']
         index = self.config_table['spectral_index'].iloc[0]
@@ -171,6 +173,22 @@ f"""{type(self).__name__} instance
     def read_data(cls, file_name, obs_id):
         data = super().read_data(file_name)
         return data.query(f'obs_id == {obs_id}')
+
+    def _fix_format(self, table):
+        table = table.copy()
+        old2new = dict(
+            mc_energy = 'true_energy',
+            mc_az = 'true_az',
+            mc_alt = 'true_alt',
+            mc_az_tel = 'pointing_az',
+            mc_alt_tel = 'pointing_alt',
+            num_showers = 'n_showers'
+        )
+        for key in old2new:
+            if key in table.columns:
+                table[old2new[key]] = table[key]
+
+        return table
 
     def get_spec_data(self, n_events, emin, emax, index=-1):
         e0 = (emin * emax)**0.5

--- a/src/srcsim/mc.py
+++ b/src/srcsim/mc.py
@@ -40,6 +40,7 @@ class MCBase:
     def get_events_key(cls, file_name):
         keys = (
             '/events/parameters',
+            '/dl1/event/telescope/parameters/LST_LSTCam',
             '/dl2/event/telescope/parameters/LST_LSTCam'
         )
         key = cls._choose_first_valid_key(file_name, keys)

--- a/src/srcsim/mc.py
+++ b/src/srcsim/mc.py
@@ -10,7 +10,99 @@ def power_law(e, e0, norm, index):
     return norm * (e/e0).decompose()**index
 
 
-class MCSample:
+class MCBase:
+    @classmethod
+    def _has_key(cls, file_name, key):
+        with tables.open_file(file_name) as table:
+            has_key = key in table
+
+        return has_key
+    
+    @classmethod
+    def _choose_first_valid_key(cls, file_name, keys):
+        for key in keys:
+            if cls._has_key(file_name, key):
+                return key
+
+        return None
+    
+    @classmethod
+    def get_config_key(cls, file_name):
+        keys = (
+            '/simulation/config',
+            '/simulation/run_config'
+        )
+        key = cls._choose_first_valid_key(file_name, keys)
+        return key
+    
+    @classmethod
+    def get_events_key(cls, file_name):
+        keys = (
+            '/events/parameters',
+            '/dl2/event/telescope/parameters/LST_LSTCam'
+        )
+        key = cls._choose_first_valid_key(file_name, keys)
+        return key
+
+    @classmethod
+    def read_config(cls, file_name):
+        with tables.open_file(file_name) as table:
+            cfg_table = table.root[cls.get_config_key(file_name)]
+
+            columns = {
+                'n_showers': ('num_showers',),
+                'shower_reuse': (),
+                'min_scatter_range': (),
+                'max_scatter_range': (),
+                'energy_range_min': (),
+                'energy_range_max': (),
+                'spectral_index': (),
+                'min_viewcone_radius': (),
+                'max_viewcone_radius': ()
+            }
+
+            data = {}
+
+            for col_name in columns:
+                if col_name in cfg_table.colnames:
+                    data[col_name] = [
+                        v[col_name] for v in cfg_table.iterrows()
+                    ]
+                else:
+                    for alternative in columns[col_name]:
+                        if alternative in cfg_table.colnames:
+                            data[col_name] = [
+                                v[alternative] for v in cfg_table.iterrows()
+                            ]
+                            break
+                if col_name not in data:
+                    raise RuntimeError(f"could not load config key {col_name} from '{file_name}'")
+
+            if 'obs_id' in cfg_table.colnames:
+                data['obs_id'] = [
+                    v['obs_id'] for v in cfg_table.iterrows()
+                ]
+            else:
+                evt_table = table.root[cls.get_events_key(file_name)]
+                row = next(evt_table.iterrows())
+                data['obs_id'] = [
+                    row['obs_id'] for _ in cfg_table.iterrows()
+                ]
+                print(
+                    "WARN: can not find 'obs_id' in the configuration table, "
+                    f"assuming {row['obs_id']} from the first event. "
+                    "Simulation results may be incorrect."
+                )
+
+        return pd.DataFrame(data=data)
+
+    @classmethod
+    def read_data(cls, file_name):
+        data = pd.read_hdf(file_name, cls.get_events_key(file_name))
+
+        return data
+
+
     def __init__(self, file_name=None, obs_id=None, data_table=None, config_table=None):
         self.units = dict(
             energy = u.TeV,

--- a/src/srcsim/mc.py
+++ b/src/srcsim/mc.py
@@ -136,7 +136,7 @@ class MCSample(MCBase):
         self.tel_pos = SkyCoord(pointing_data['pointing_az'], pointing_data['pointing_alt'], unit=self.units['angle'], frame='altaz')
         
         # Working out the simulation spectrum
-        rmin, rmax = self.config_table[['min_scatter_range', 'max_scatter_range']].iloc[0] * self.units['distance']
+        rmin, rmax = self.config_table[['min_scatter_range', 'max_scatter_range']].iloc[0].values * self.units['distance']
         ground_area = np.pi * (rmax**2 - rmin**2)
         nevents = self.config_table['n_showers'].iloc[0] * self.config_table['shower_reuse'].iloc[0]
         emin = self.config_table['energy_range_min'].iloc[0] * self.units['energy']
@@ -212,7 +212,7 @@ f"""{type(self).__name__} instance
         return power_law(energy, **self.spec_data)
     
     def dndo(self, coord):
-        offset_min, offset_max = self.config_table[['min_viewcone_radius', 'max_viewcone_radius']].iloc[0] * self.units['viewcone']
+        offset_min, offset_max = self.config_table[['min_viewcone_radius', 'max_viewcone_radius']].iloc[0].values * self.units['viewcone']
         sky_area = 2 * np.pi * (np.cos(offset_min) - np.cos(offset_max)) * u.sr
         norm = 1 / sky_area
 

--- a/src/srcsim/mc.py
+++ b/src/srcsim/mc.py
@@ -279,6 +279,7 @@ f"""{type(self).__name__} instance
         return samples
 
     def get_closest(self, target_position):
+        target_position = SkyCoord(target_position.altaz.az, target_position.altaz.alt, frame='altaz')
         tel_pos = SkyCoord([sample.tel_pos for sample in self.samples])
         separation = tel_pos.separation(target_position)
         idx = separation.argmin()
@@ -286,6 +287,7 @@ f"""{type(self).__name__} instance
         return MCCollection(samples=(self.samples[idx],))
 
     def get_nearby(self, target_position, search_radius):
+        target_position = SkyCoord(target_position.altaz.az, target_position.altaz.alt, frame='altaz')
         samples = tuple(
             filter(
                 lambda sample: sample.tel_pos.separation(target_position) <= search_radius,
@@ -296,8 +298,8 @@ f"""{type(self).__name__} instance
         return MCCollection(samples=samples)
 
     def get_in_box(self, target_position, max_lon_offset, max_lat_offset):
-        tel_pos = SkyCoord([sample.tel_pos for sample in self.samples])
         target_position = SkyCoord(target_position.altaz.az, target_position.altaz.alt, frame='altaz')
+        tel_pos = SkyCoord([sample.tel_pos for sample in self.samples])
 
         lon_offset, lat_offset = tel_pos.altaz.spherical_offsets_to(target_position.altaz)
         inbox = (np.absolute(lon_offset) <= max_lon_offset) & (np.absolute(lat_offset) <= max_lat_offset)

--- a/src/srcsim/mc.py
+++ b/src/srcsim/mc.py
@@ -145,11 +145,13 @@ class MCSample(MCBase):
         self.spec_data = self.get_spec_data(nevents, emin, emax, index)
         self.spec_data['norm'] /= ground_area
 
-        cam_x, cam_y = self.data_table[['src_x', 'src_y']].to_numpy().transpose() * self.units['distance'] * self.cam2angle
-        self.evt_coord = SkyCoord(cam_x, cam_y, frame=self.tel_pos.skyoffset_frame())
+        alt, az = self.data_table[['true_alt', 'true_az']].to_numpy().transpose()
+        _unit = 'rad' if 'mc_alt' in self.data_table.columns else 'deg'
+        self.evt_coord = SkyCoord(az, alt, frame='altaz', unit=_unit)
+        self.evt_coord = self.evt_coord.transform_to(self.tel_pos.skyoffset_frame())
 
-        self.evt_energy = self.data_table['mc_energy'].to_numpy() * self.units['energy']
-        
+        self.evt_energy = self.data_table['true_energy'].to_numpy() * self.units['energy']
+    
     def __repr__(self):
         print(
 f"""{type(self).__name__} instance

--- a/src/srcsim/mc.py
+++ b/src/srcsim/mc.py
@@ -103,6 +103,7 @@ class MCBase:
         return data
 
 
+class MCSample(MCBase):
     def __init__(self, file_name=None, obs_id=None, data_table=None, config_table=None):
         self.units = dict(
             energy = u.TeV,
@@ -125,7 +126,8 @@ class MCBase:
             self.file_name = file_name
             self.obs_id = obs_id
             self.config_table = self.read_config(file_name, obs_id)
-            self.data_table = pd.read_hdf(file_name, 'dl2/event/telescope/parameters/LST_LSTCam').query(f'obs_id == {obs_id}')
+            self.data_table = self.read_data(file_name, obs_id)
+
 
         # Getting the telescope pointing
         pointing_data = self.data_table[['mc_az_tel', 'mc_alt_tel']].mean()
@@ -159,35 +161,16 @@ f"""{type(self).__name__} instance
         )
 
         return super().__repr__()
-    
+
     @classmethod
     def read_config(cls, file_name, obs_id):
-        with tables.open_file(file_name) as table:
-            cfg_table = table.root['/simulation/run_config']
-            obs_ids = [v['obs_id'] for v in cfg_table.iterrows()]
-
-            columns = (
-                'obs_id',
-                'num_showers',
-                'shower_reuse',
-                'min_scatter_range',
-                'max_scatter_range',
-                'energy_range_min',
-                'energy_range_max',
-                'spectral_index',
-                'min_viewcone_radius',
-                'max_viewcone_radius'
-            )
-
-            obs_idx = obs_ids.index(obs_id)
-
-            data = {}
-
-            for col_name in columns:
-                col_idx = cfg_table.colnames.index(col_name)
-                data[col_name] = (cfg_table[obs_idx][col_idx], )
-
-            return pd.DataFrame(data=data)
+        config = super().read_config(file_name)
+        return config.query(f'obs_id == {obs_id}')
+        
+    @classmethod
+    def read_data(cls, file_name, obs_id):
+        data = super().read_data(file_name)
+        return data.query(f'obs_id == {obs_id}')
 
     def get_spec_data(self, n_events, emin, emax, index=-1):
         e0 = (emin * emax)**0.5

--- a/src/srcsim/mc.py
+++ b/src/srcsim/mc.py
@@ -223,7 +223,7 @@ f"""{type(self).__name__} instance
         return self.dnde(energy) * self.dndo(coord)
 
 
-class MCCollection:
+class MCCollection(MCBase):
     def __init__(self, file_mask=None, samples=None):
         self.file_mask = file_mask
 
@@ -244,44 +244,15 @@ f"""{type(self).__name__} instance
 
     @classmethod
     def read_obs_ids(cls, file_name):
-        with tables.open_file(file_name, 'r') as data:
-            cfg_table = data.root['/simulation/run_config']
-            obs_ids = [v['obs_id'] for v in cfg_table.iterrows()]
+        obs_ids = cls.read_config(file_name)['obs_id'].values
 
         return obs_ids
-
-    @classmethod
-    def read_config(cls, file_name):
-        with tables.open_file(file_name) as table:
-            cfg_table = table.root['/simulation/run_config']
-
-            columns = (
-                'obs_id',
-                'num_showers',
-                'shower_reuse',
-                'min_scatter_range',
-                'max_scatter_range',
-                'energy_range_min',
-                'energy_range_max',
-                'spectral_index',
-                'min_viewcone_radius',
-                'max_viewcone_radius'
-            )
-
-            data = {}
-
-            for col_name in columns:
-                data[col_name] = [
-                    v[col_name] for v in cfg_table.iterrows()
-                ]
-
-        return pd.DataFrame(data=data)
 
     @classmethod
     def read_file(cls, file_name):
         obs_ids = cls.read_obs_ids(file_name)
 
-        data = pd.read_hdf(file_name, "dl2/event/telescope/parameters/LST_LSTCam")
+        data = cls.read_data(file_name)
         config = cls.read_config(file_name)
 
         samples = tuple(

--- a/src/srcsim/mc.py
+++ b/src/srcsim/mc.py
@@ -155,7 +155,7 @@ class MCSample(MCBase):
         self.evt_energy = self.data_table['true_energy'].to_numpy() * self.units['energy']
 
         # Filtering out events with excessive offsets (e.g. due to the simulation numerical accuracy)
-        offset_min, offset_max = self.config_table[['min_viewcone_radius', 'max_viewcone_radius']].iloc[0] * self.units['viewcone']
+        offset_min, offset_max = self.config_table[['min_viewcone_radius', 'max_viewcone_radius']].iloc[0].values * self.units['viewcone']
         evt_offset = self.evt_coord.separation(self.tel_pos)
 
         in_fov = (evt_offset >= offset_min) & (evt_offset <= offset_max)

--- a/src/srcsim/run.py
+++ b/src/srcsim/run.py
@@ -299,11 +299,24 @@ f"""{type(self).__name__} instance
                     )
 
                     # Reconstructed events coordinates
-                    if 'reco_src_x' in evt.columns:
+                    if 'reco_alt' in evt.columns:
+                        _reco_in_offset_frame = SkyCoord(
+                            evt['reco_az'].to_numpy(),
+                            evt['reco_alt'].to_numpy(),
+                            unit=sample.units['angle'],
+                            frame='altaz'
+                        ).transform_to(
+                            sample.tel_pos.skyoffset_frame()
+                        )
                         reco_coords = SkyCoord(
-                            evt['reco_src_x'].to_numpy() * sample.units['distance'] * sample.cam2angle,
-                            evt['reco_src_y'].to_numpy() * sample.units['distance'] * sample.cam2angle,
-                            frame=offset_frame
+                            _reco_in_offset_frame.lon,
+                            _reco_in_offset_frame.lat,
+                            evt['reco_alt'].to_numpy(),
+                            unit=sample.units['angle'],
+                            frame=AltAz(
+                                location=current_tel_pos.altaz.frame.location,
+                                obstime=current_tel_pos.altaz.frame.obstime
+                            )
                         )
                         evt = evt.assign(
                             reco_az = reco_coords.altaz.az.to('rad').value,
@@ -324,7 +337,7 @@ f"""{type(self).__name__} instance
                         ra_tel = np.zeros(0),
                         dec_tel = np.zeros(0)
                     )
-                    if 'reco_src_x' in evt.columns:
+                    if 'reco_alt' in evt.columns:
                         evt = evt.assign(
                             reco_az = np.zeros(0),
                             reco_alt = np.zeros(0),

--- a/src/srcsim/run.py
+++ b/src/srcsim/run.py
@@ -231,6 +231,15 @@ f"""{type(self).__name__} instance
                     current_tel_pos = current_tel_pos[evt_indices]
                     coords = coords[row_idx]
 
+                    # Randomly scatter arrival times of the repeated (i.e. identical) events
+                    scale = 100e-6  # seconds
+                    arrival_time += np.concatenate([
+                        np.tile(
+                            np.random.normal(scale=scale*np.arange(n)),
+                            rows_per_event[i]
+                        )
+                        for i, n in enumerate(evt_copy_counts)
+                    ])
                 else:
                     # Empty but schema-consistent
                     evt = sample.data_table.iloc[0:0].assign(event_copy_id=np.zeros(0, dtype=int))

--- a/src/srcsim/run.py
+++ b/src/srcsim/run.py
@@ -134,8 +134,19 @@ f"""{type(self).__name__} instance
             nsamples = len(mc.samples)
 
             for sample in mc.samples:
-                # Randomly distributing events within the time bin
-                arrival_time = np.random.uniform(tstart.unix, (tstart+dt).unix, size=len(sample.data_table))
+                # groupby.indices gives: {(obs_id, event_id): array([row indices])}
+                event_groups = sample.data_table.groupby(['obs_id', 'event_id']).indices
+
+                # event-level index
+                event_keys = list(event_groups.keys())
+                n_events_total = len(event_keys)
+
+                # Randomly distributing events within the time bin - single arrival time per event
+                arrival_time = np.random.uniform(
+                    tstart.unix,
+                    (tstart + dt).unix,
+                    size=n_events_total
+                )
 
                 # Recalculating telescope Alt/Az for the mock event arrival times
                 current_frame = AltAz(
@@ -151,24 +162,21 @@ f"""{type(self).__name__} instance
                     location=current_tel_pos.altaz.frame.location,
                     obstime=current_tel_pos.altaz.frame.obstime
                 )
+                # Row to event index mapping
+                row_to_evt = np.empty(len(sample.data_table), dtype=int)
+                for i, k in enumerate(event_keys):
+                    row_to_evt[event_groups[k]] = i
                 coords = SkyCoord(
                     sample.evt_coord.skyoffsetaltaz.lon,
                     sample.evt_coord.skyoffsetaltaz.lat,
-                    frame=offset_frame
+                    frame=offset_frame[row_to_evt]
                 )
+
                 expected_flux = source.dndedo(sample.evt_energy, coords.icrs)
                 model_flux = sample.dndedo(sample.evt_energy, sample.evt_coord)
 
-                # Per-row weights (no copy of data_table)
                 row_weights = (1 / nsamples * dt * expected_flux / model_flux).decompose().value
 
-                df = sample.data_table
-
-                # groupby.indices gives: {(obs_id, event_id): array([row indices])}
-                event_groups = df.groupby(['obs_id', 'event_id']).indices
-
-                # row_weights: NumPy array aligned with df rows
-                event_keys = list(event_groups.keys())
                 event_weights = np.fromiter(
                     (row_weights[event_groups[k]].sum() for k in event_keys),
                     dtype=float,
@@ -208,15 +216,19 @@ f"""{type(self).__name__} instance
                         rows_flat,
                         np.repeat(evt_copy_counts, rows_per_event)
                     )
+                    evt_indices = np.repeat(
+                        evt_indices,
+                        evt_copy_counts * rows_per_event
+                    )
                     event_copy_id = np.concatenate([
                         np.repeat(np.arange(n), rows_per_event[i])
                         for i, n in enumerate(evt_copy_counts)
                     ])
 
                     evt = df.iloc[row_idx].assign(event_copy_id=event_copy_id)
-                    offset_frame = offset_frame[row_idx]
-                    arrival_time = arrival_time[row_idx]
-                    current_tel_pos = current_tel_pos[row_idx]
+                    offset_frame = offset_frame[evt_indices]
+                    arrival_time = arrival_time[evt_indices]
+                    current_tel_pos = current_tel_pos[evt_indices]
                     coords = coords[row_idx]
 
                 else:

--- a/src/srcsim/run.py
+++ b/src/srcsim/run.py
@@ -174,6 +174,7 @@ f"""{type(self).__name__} instance
                 offset_frame = offset_frame[idx]
                 arrival_time = arrival_time[idx]
                 current_tel_pos = current_tel_pos[idx]
+                coords = coords[idx]
 
                 # Dropping the columns we're going to (re-)fill
                 evt = evt.drop(
@@ -182,6 +183,10 @@ f"""{type(self).__name__} instance
                 )
                 evt = evt.drop(
                     columns=['mc_az_tel', 'mc_alt_tel', 'az_tel', 'alt_tel', 'ra_tel', 'dec_tel'],
+                    errors='ignore'
+                )
+                evt = evt.drop(
+                    columns=['true_az', 'true_alt'],
                     errors='ignore'
                 )
                 evt = evt.drop(
@@ -204,6 +209,12 @@ f"""{type(self).__name__} instance
                         alt_tel = current_tel_pos.alt.to('rad').value,
                         ra_tel = self.tel_pos.icrs.ra.to('rad').value,
                         dec_tel = self.tel_pos.icrs.dec.to('rad').value
+                    )
+
+                    # True events coordinates
+                    evt = evt.assign(
+                        true_az = coords.altaz.az.to('rad').value,
+                        true_alt = coords.altaz.alt.to('rad').value,
                     )
 
                     # Reconstructed events coordinates

--- a/src/srcsim/run.py
+++ b/src/srcsim/run.py
@@ -159,22 +159,73 @@ f"""{type(self).__name__} instance
                 expected_flux = source.dndedo(sample.evt_energy, coords.icrs)
                 model_flux = sample.dndedo(sample.evt_energy, sample.evt_coord)
 
-                weights = (1 / nsamples * dt * expected_flux / model_flux).decompose()
+                # Per-row weights (no copy of data_table)
+                row_weights = (1 / nsamples * dt * expected_flux / model_flux).decompose().value
 
-                n_mc_events = len(sample.evt_energy)
-                n_events = np.random.poisson(weights.sum())
-                p = weights / weights.sum()
-                idx = np.random.choice(
-                    np.arange(n_mc_events),
-                    size=n_events,
-                    p=p
+                df = sample.data_table
+
+                # groupby.indices gives: {(obs_id, event_id): array([row indices])}
+                event_groups = df.groupby(['obs_id', 'event_id']).indices
+
+                # row_weights: NumPy array aligned with df rows
+                event_keys = list(event_groups.keys())
+                event_weights = np.fromiter(
+                    (row_weights[event_groups[k]].sum() for k in event_keys),
+                    dtype=float,
+                    count=len(event_keys)
                 )
 
-                evt = sample.data_table.iloc[idx]
-                offset_frame = offset_frame[idx]
-                arrival_time = arrival_time[idx]
-                current_tel_pos = current_tel_pos[idx]
-                coords = coords[idx]
+                # Poisson draw
+                n_events = np.random.poisson(event_weights.sum())
+
+                if n_events > 0:
+                    p = event_weights / event_weights.sum()
+
+                    # Sample events
+                    idx_evt = np.random.choice(
+                        np.arange(len(event_keys)),
+                        size=n_events,
+                        p=p
+                    )
+
+                    # Count copies per event
+                    copy_counts = {}
+                    for i in idx_evt:
+                        copy_counts[i] = copy_counts.get(i, 0) + 1
+                    
+                    evt_indices, evt_copy_counts = np.unique(idx_evt, return_counts=True)
+                    rows_per_event = np.fromiter(
+                        (len(event_groups[event_keys[i]]) for i in evt_indices),
+                        dtype=int,
+                        count=len(evt_indices)
+                    )
+                    # Concatenate row indices per event
+                    rows_flat = np.concatenate(
+                        [event_groups[event_keys[i]] for i in evt_indices]
+                    )
+                    # Repeat each event's rows according to copy count
+                    row_idx = np.repeat(
+                        rows_flat,
+                        np.repeat(evt_copy_counts, rows_per_event)
+                    )
+                    event_copy_id = np.concatenate([
+                        np.repeat(np.arange(n), rows_per_event[i])
+                        for i, n in enumerate(evt_copy_counts)
+                    ])
+
+                    evt = df.iloc[row_idx].assign(event_copy_id=event_copy_id)
+                    offset_frame = offset_frame[row_idx]
+                    arrival_time = arrival_time[row_idx]
+                    current_tel_pos = current_tel_pos[row_idx]
+                    coords = coords[row_idx]
+
+                else:
+                    # Empty but schema-consistent
+                    evt = df.iloc[0:0].assign(event_copy_id=np.zeros(0, dtype=int))
+                    offset_frame = offset_frame[0:0]
+                    arrival_time = arrival_time[0:0]
+                    current_tel_pos = current_tel_pos[0:0]
+                    coords = coords[0:0]
 
                 # Dropping the columns we're going to (re-)fill
                 evt = evt.drop(

--- a/src/srcsim/run.py
+++ b/src/srcsim/run.py
@@ -207,17 +207,18 @@ f"""{type(self).__name__} instance
                     )
 
                     # Reconstructed events coordinates
-                    reco_coords = SkyCoord(
-                        evt['reco_src_x'].to_numpy() * sample.units['distance'] * sample.cam2angle,
-                        evt['reco_src_y'].to_numpy() * sample.units['distance'] * sample.cam2angle,
-                        frame=offset_frame
-                    )
-                    evt = evt.assign(
-                        reco_az = reco_coords.altaz.az.to('rad').value,
-                        reco_alt = reco_coords.altaz.alt.to('rad').value,
-                        reco_ra = reco_coords.icrs.ra.to('rad').value,
-                        reco_dec = reco_coords.icrs.dec.to('rad').value,
-                    )
+                    if 'reco_src_x' in evt.columns:
+                        reco_coords = SkyCoord(
+                            evt['reco_src_x'].to_numpy() * sample.units['distance'] * sample.cam2angle,
+                            evt['reco_src_y'].to_numpy() * sample.units['distance'] * sample.cam2angle,
+                            frame=offset_frame
+                        )
+                        evt = evt.assign(
+                            reco_az = reco_coords.altaz.az.to('rad').value,
+                            reco_alt = reco_coords.altaz.alt.to('rad').value,
+                            reco_ra = reco_coords.icrs.ra.to('rad').value,
+                            reco_dec = reco_coords.icrs.dec.to('rad').value,
+                        )
                 else:
                     evt = evt.assign(
                         dragon_time = np.zeros(0),
@@ -231,12 +232,13 @@ f"""{type(self).__name__} instance
                         ra_tel = np.zeros(0),
                         dec_tel = np.zeros(0)
                     )
-                    evt = evt.assign(
-                        reco_az = np.zeros(0),
-                        reco_alt = np.zeros(0),
-                        reco_ra = np.zeros(0),
-                        reco_dec = np.zeros(0)
-                    )
+                    if 'reco_src_x' in evt.columns:
+                        evt = evt.assign(
+                            reco_az = np.zeros(0),
+                            reco_alt = np.zeros(0),
+                            reco_ra = np.zeros(0),
+                            reco_dec = np.zeros(0)
+                        )
 
                 events.append(evt)
 

--- a/src/srcsim/run.py
+++ b/src/srcsim/run.py
@@ -221,7 +221,7 @@ f"""{type(self).__name__} instance
                         evt_copy_counts * rows_per_event
                     )
                     event_copy_id = np.concatenate([
-                        np.repeat(np.arange(n), rows_per_event[i])
+                        np.tile(np.arange(n), rows_per_event[i])
                         for i, n in enumerate(evt_copy_counts)
                     ])
 

--- a/src/srcsim/run.py
+++ b/src/srcsim/run.py
@@ -225,7 +225,7 @@ f"""{type(self).__name__} instance
                         for i, n in enumerate(evt_copy_counts)
                     ])
 
-                    evt = df.iloc[row_idx].assign(event_copy_id=event_copy_id)
+                    evt = sample.data_table.iloc[row_idx].assign(event_copy_id=event_copy_id)
                     offset_frame = offset_frame[evt_indices]
                     arrival_time = arrival_time[evt_indices]
                     current_tel_pos = current_tel_pos[evt_indices]
@@ -233,7 +233,7 @@ f"""{type(self).__name__} instance
 
                 else:
                     # Empty but schema-consistent
-                    evt = df.iloc[0:0].assign(event_copy_id=np.zeros(0, dtype=int))
+                    evt = sample.data_table.iloc[0:0].assign(event_copy_id=np.zeros(0, dtype=int))
                     offset_frame = offset_frame[0:0]
                     arrival_time = arrival_time[0:0]
                     current_tel_pos = current_tel_pos[0:0]

--- a/src/srcsim/run.py
+++ b/src/srcsim/run.py
@@ -323,6 +323,11 @@ f"""{type(self).__name__} instance
                             reco_dec = np.zeros(0)
                         )
 
+                evt = evt.drop('mc_src_name', errors='ignore')
+                evt = evt.assign(
+                    mc_src_name = np.repeat(source.name, len(evt))
+                )
+
                 events.append(evt)
 
         events = pd.concat(events)

--- a/src/srcsim/scripts/sim_run.py
+++ b/src/srcsim/scripts/sim_run.py
@@ -1,4 +1,5 @@
 import yaml
+import glob
 import datetime
 import argparse
 import pandas as pd
@@ -92,7 +93,11 @@ def main():
     events = run.time_sort(events)
     events = run.update_time_delta(events)
 
-    events.to_hdf(cfg['io']['out'] + f'run{run.id}.h5', 'dl2/event/telescope/parameters/LST_LSTCam')
+    # Write events under the key from MC files
+    _key = list(mc.keys())[0]
+    _files = glob.glob(mc[_key].file_mask)
+    events_key = MCCollection.get_events_key(_files[0])
+    events.to_hdf(cfg['io']['out'] + f'run{run.id}.h5', key=events_key)
 
     info_message('Simulation complete')
 

--- a/src/srcsim/spec.py
+++ b/src/srcsim/spec.py
@@ -9,7 +9,7 @@ def generator(config):
     else:
         cfg = config
 
-    for par in ('norm', 'index', 'ecut', 'beta'):
+    for par in ('norm', 'e0', 'index', 'ecut', 'ebr', 'beta'):
         if par in cfg:
             cfg[par] = u.Quantity(cfg[par])
 


### PR DESCRIPTION
Various fixes to ensure compatibility with newer Python versions and LST Prod6 MCs (including multiple telescopes)

**Changes**

_New:_
- mc: prod6 dl1 files support
- data run: simulate arrival time per gamma-ray event, coherent across telescopes

_Fixes:_
- mc: fix pandas column value retrieval
- spectrum: add missing params conversion to units
- data run: add missing mc_src_name
- simrun: write events under the key from MC files instead of the hard-coded one

_Refactoring:_
- mc: refactor mccollection and mcsample to use a single base class to unify common methods